### PR TITLE
added container_name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.8'
 
 services:
   zurg:
-    image: ghcr.io/debridmediamanager/zurg-testing:latest
+    image: ghcr.io/debridmediamanager/zurg-testing:latest    
+    container_name: zurg
     restart: unless-stopped
     ports:
       - 9999:9999
@@ -13,6 +14,7 @@ services:
 
   rclone:
     image: rclone/rclone:latest
+    container_name: rclone
     restart: unless-stopped
     environment:
       TZ: Europe/Berlin


### PR DESCRIPTION
added `container_name` so you can use `depends_on` in plex to make sure zurg will start always first. 

example:
```
    image: plexinc/pms-docker
    container_name: plex
    restart: unless-stopped
    volumes:
      - ./config:/config
    ports:
      - 32400:32400
    depends_on:
      - zurg
      - rclone
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker configuration to explicitly name containers for improved management and identification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->