### PR TITLE
Fix bug in plex_update.sh

### DIFF
--- a/scripts/plex_update.sh
+++ b/scripts/plex_update.sh
@@ -16,8 +16,9 @@ section_ids=$(curl -sLX GET "$plex_url/library/sections" -H "X-Plex-Token: $toke
 
 for arg in "$@"
 do
-    parsed_arg="${arg//\\}"
-    echo $parsed_arg
+    # POSIX-compliant way to remove backslashes
+    parsed_arg=$(echo "$arg" | tr -d '\\')
+    echo "$parsed_arg"
     modified_arg="$zurg_mount/$parsed_arg"
     echo "Detected update on: $arg"
     echo "Absolute path: $modified_arg"
@@ -25,11 +26,8 @@ do
     for section_id in $section_ids
     do
         echo "Section ID: $section_id"
-
-        curl -G -H "X-Plex-Token: $token" --data-urlencode "path=$modified_arg" $plex_url/library/sections/$section_id/refresh
+        curl -G -H "X-Plex-Token: $token" --data-urlencode "path=$modified_arg" "$plex_url/library/sections/$section_id/refresh"
     done
 done
 
 echo "All updated sections refreshed"
-
-# credits to godver3, wasabipls

--- a/scripts/plex_update.sh
+++ b/scripts/plex_update.sh
@@ -16,8 +16,8 @@ section_ids=$(curl -sLX GET "$plex_url/library/sections" -H "X-Plex-Token: $toke
 
 for arg in "$@"
 do
-    # POSIX-compliant way to remove backslashes
-    parsed_arg=$(echo "$arg" | tr -d '\\')
+    # POSIX-compliant way to remove backslashes (using printf + tr instead of Bash substitution)
+    parsed_arg=$(printf '%s' "$arg" | tr -d '\\')
     echo "$parsed_arg"
     modified_arg="$zurg_mount/$parsed_arg"
     echo "Detected update on: $arg"

--- a/scripts/plex_update.sh
+++ b/scripts/plex_update.sh
@@ -31,3 +31,5 @@ do
 done
 
 echo "All updated sections refreshed"
+
+# credits to godver3, wasabipls, xXSalamanderXx

--- a/scripts/plex_update.sh
+++ b/scripts/plex_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # PLEX PARTIAL SCAN script or PLEX UPDATE script
 # When zurg detects changes, it can trigger this script IF your config.yml contains


### PR DESCRIPTION
This commit addresses an inconsistency in the script execution environment between the zurg config.yml and the plex_update.sh script. The zurg config.yml calls the plex_update.sh script using sh, while the plex_update.sh script itself specifies #!/bin/bash as its shebang. This can lead to compatibility issues and unexpected behavior when the script is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the script to use a more universal shell interpreter for improved compatibility.
  - Improved handling of special characters and safer output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->